### PR TITLE
Fixed headers when comma is within the value

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -335,7 +335,7 @@ var rootCmd = &cobra.Command{
 				}
 
 				req, _ := http.NewRequest(flags.method, url, nil)
-				tget.PrepareRequest(req, flags.headers, flags.cookies, flags.body, flags.useragent)
+				tget.PrepareRequest(req, flags.headers, flags.cookies, flags.useragent, flags.body)
 
 				baseFileName := path.Base(req.URL.Path)
 				if baseFileName == "." || baseFileName == "/" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -430,7 +430,7 @@ func init() {
 	// Headers, cookies, ssl, etc
 	rootCmd.Flags().BoolVarP(&flags.followRedirect, "follow-redirect", "f", false, "follow HTTP redirects")
 	rootCmd.Flags().BoolVarP(&flags.unsafeTLS, "unsafe-tls", "k", false, "skip TLS certificates validation")
-	rootCmd.Flags().StringSliceVarP(&flags.headers, "header", "H", []string{}, "header(s) to include in all requests")
+	rootCmd.Flags().StringArrayVarP(&flags.headers, "header", "H", []string{}, "header(s) to include in all requests")
 	rootCmd.Flags().StringVarP(&flags.cookies, "cookies", "b", "", "cookie(s) to include in all requests")
 	rootCmd.Flags().StringVarP(&flags.body, "data", "d", "", "body of request to send")
 	rootCmd.Flags().StringVarP(&flags.useragent, "useragent", "U", fmt.Sprintf("tget/%v", tget.Version), "useraget to use when sending requests")

--- a/tget/tget.go
+++ b/tget/tget.go
@@ -20,17 +20,13 @@ var TorrcTemplate string
 type TorGet struct {
 }
 
-var Version = "v0.3.1"
+var Version = "v0.3.2"
 
 func PrepareRequest(req *http.Request, headers []string, cookies, useragent, body string) {
 	for _, h := range headers {
-		split := strings.Split(h, "=")
+		split := strings.SplitN(h, ":", 2)
 		k := split[0]
-		v := ""
-		if len(split) > 1 {
-			v = strings.Join(split[1:], "=")
-		}
-
+		v := strings.TrimSpace(split[1])
 		req.Header.Add(k, v)
 	}
 	if cookies != "" {


### PR DESCRIPTION
This fixes a problem when you try to assign headers that contains a comma in the value. Here is an [example](https://github.com/spf13/cobra/issues/661#issuecomment-377684634) of the differences between StringSlice and StringArray

Using StringSliceVarP
```
❯ ./tget-src/torget http://xeuvs5poflczn5i5kbynb5rupmidb5zjuza6gaq2... -H 'Accept=text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/png,image/svg+xml,*/*;q=0.8'
```
Results in
```
header: Accept=text/html                                                                                                                                                             
header: application/xhtml+xml                                                                                                                                                        
header: application/xml;q=0.9                                                                                                                                                        
header: image/avif                                                                                                                                                                   
header: image/webp                                                                                                                                                                   
header: image/png                                                                                                                                                                    
header: image/svg+xml                                                                                                                                                                
header: */*;q=0.8                                                                                                                                                                    
header: Accept-Encoding=gzip                                                                                                                                                         
header:  deflate                                                                                                                                                                     
header:  br                                                                                                                                                                          
header:  zstd
```

Using StringArrayVarP
```
header: Accept=text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/png,image/svg+xml,*/*;q=0.8
```